### PR TITLE
add link for gh in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ You will be running a local node server configured with Hellō is less than a mi
 ### Create your own fork of hello-nextjs-starter
 You will need:
 - git
-- gh 
+- [gh](https://cli.github.com/) 
 - Vercel or Netlify account
 ```
 git remote rename origin upstream


### PR DESCRIPTION
I didn't have `gh` installed - a quicklink would reduce a small bit of friction here